### PR TITLE
[Java] Support camelCase enum type identifiers

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -3074,7 +3074,8 @@ public class JavaGenerator implements CodeGenerator
 
         if (fieldToken.isConstantEncoding())
         {
-            final String enumValueStr = fieldToken.encoding().constValue().toString();
+            final String enumValueStr = formatClassName(
+                fieldToken.encoding().constValue().toString());
 
             new Formatter(sb).format(
                 "\n" +


### PR DESCRIPTION
The type identifier was previously used as-is (e.g. `carType`) in the generated code for enums while generated enums always start with a capital letter (`CarType`).